### PR TITLE
Add dev followers server

### DIFF
--- a/configs/prometheus/prometheus.yml
+++ b/configs/prometheus/prometheus.yml
@@ -31,6 +31,7 @@ scrape_configs:
     - "one.planetary.pub:9100"
     - "two.planetary.pub:9100"
     - "reportinator2.ansible.fun:9100"
+    - "daniel.dev.nos.social:9100"
 - job_name: nos
   static_configs:
   - targets:
@@ -42,6 +43,7 @@ scrape_configs:
     - "rss.nos.social:9100"
     - "relay.nos.social:9100"
     - "reportinator2.ansible.fun:9100"
+    - "daniel.dev.nos.social:9100"
 - job_name: internal_tools
   static_configs:
   - targets:
@@ -73,4 +75,7 @@ scrape_configs:
 - job_name: reportinator
   static_configs:
   - targets: ["reportinator2.ansible.fun"]
+- job_name: followers
+  static_configs:
+  - targets: ["daniel.dev.nos.social"]
 


### PR DESCRIPTION
This adds daniel.dev.nos.social for both node exporter dashboard and for a new followers server dashboard.
Once we have the production server we can update the followers server dashboard. I think the node exporter for dev machines can remain.