### PR TITLE
temporarily lengthen the instance-down alerts from prometheus

### DIFF
--- a/configs/prometheus/rules.yml
+++ b/configs/prometheus/rules.yml
@@ -11,7 +11,7 @@ groups:
           severity: moderate
       - alert: InstanceDown
         expr: up == 0
-        for: 1m
+        for: 1h
         annotations:
           title: 'Instance is down: {{ $labels.instance }}/{{ $labels.job }}'
           description: 'The job {{ $labels.job}}({{ $labels.instance }}) has been down for more than one minute.'

--- a/configs/prometheus/rules.yml
+++ b/configs/prometheus/rules.yml
@@ -14,6 +14,6 @@ groups:
         for: 1h
         annotations:
           title: 'Instance is down: {{ $labels.instance }}/{{ $labels.job }}'
-          description: 'The job {{ $labels.job}}({{ $labels.instance }}) has been down for more than one minute.'
+          description: 'The job {{ $labels.job}}({{ $labels.instance }}) has been down for more than one hour.'
         labels:
           severity: critical


### PR DESCRIPTION
This just changes the aggregation window to 1h, instead of 1m, while we are waiting for work to be completed on resolution for the instance-down issues.

per: https://github.com/verse-pbc/issues/issues/197